### PR TITLE
fixes boundary mismatch in MMDataFrame

### DIFF
--- a/src/main/java/com/jug/mmpreprocess/MMDataFrame.java
+++ b/src/main/java/com/jug/mmpreprocess/MMDataFrame.java
@@ -415,7 +415,7 @@ public class MMDataFrame {
 			ip.invert();
 		}
 
-		final RandomAccessible<FloatType> ra = Views.extendValue(ImageJFunctions.wrap( duplicate ), new FloatType(0.0f));
+		final RandomAccessible<FloatType> ra = Views.extendValue(ImageJFunctions.wrapFloat( duplicate ), new FloatType(0.0f));
 		final RandomAccessibleInterval< FloatType > rai = Views.interval( ra, channelImages.get( 0 ) );
 
 		channelImages.add( 0, rai );


### PR DESCRIPTION
Fix for this error I got when opening mmpreprocess in Eclipse:
```
Bound mismatch: The generic method extendValue(F, T) of type Views is not applicable for the arguments (Img<NumericType<NumericType<T>&NativeType<T>>&NativeType<NumericType<T>&NativeType<T>>>, FloatType). The inferred type Img<NumericType<NumericType<T>&NativeType<T>>&NativeType<NumericType<T>&NativeType<T>>> is not a valid substitute for the bounded parameter <F extends RandomAccessibleInterval<T>>	MMDataFrame.java	/MMPreprocess_/src/main/java/com/jug/mmpreprocess	line 418	Java Problem
```