### PR TITLE
Enable fluorescence dataset tracking

### DIFF
--- a/src/main/java/com/jug/mmpreprocess/CropArea.java
+++ b/src/main/java/com/jug/mmpreprocess/CropArea.java
@@ -13,6 +13,13 @@ public class CropArea {
 		this.bottom = bottom;
 		this.right = right;
 	}
+	
+	public CropArea( final CropArea copy ) {
+		this.top = copy.top;
+		this.left = copy.left;
+		this.bottom = copy.bottom;
+		this.right = copy.right;
+	}
 
 	public long getCenterCoordinate() {
 		return ( right + left ) / 2;

--- a/src/main/java/com/jug/mmpreprocess/MMDataFrame.java
+++ b/src/main/java/com/jug/mmpreprocess/MMDataFrame.java
@@ -3,22 +3,19 @@
  */
 package com.jug.mmpreprocess;
 
+import com.jug.mmpreprocess.oldshit.GrowthLineFrame;
+import com.jug.mmpreprocess.oldshit.Loops;
+import com.jug.mmpreprocess.oldshit.VarOfRai;
+import com.jug.mmpreprocess.util.FloatTypeImgLoader;
+
+import io.scif.img.ImgIOException;
+
 import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.jug.mmpreprocess.oldshit.GrowthLineFrame;
-import com.jug.mmpreprocess.oldshit.Loops;
-import com.jug.mmpreprocess.oldshit.VarOfRai;
-import com.jug.mmpreprocess.util.FloatTypeImgLoader;
-
-import ij.IJ;
-import ij.ImagePlus;
-import ij.plugin.Duplicator;
-import ij.process.ImageProcessor;
-import io.scif.img.ImgIOException;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -33,6 +30,11 @@ import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
+
+import ij.IJ;
+import ij.ImagePlus;
+import ij.plugin.Duplicator;
+import ij.process.ImageProcessor;
 
 /**
  * @author jug
@@ -71,6 +73,24 @@ public class MMDataFrame {
 		}
 
 		basisName = prefix;
+	}
+	
+	public MMDataFrame( final MMDataFrame copy ) {
+		this.numChannels = copy.numChannels;
+		this.minChannelIdx = copy.minChannelIdx;
+		this.channelSourceFilenames = new ArrayList<>(copy.channelSourceFilenames);
+		
+		sanityChecks();
+
+		try {
+			this.t = FloatTypeImgLoader.getTimeFromFilename(channelSourceFilenames.get( 0 )); //Integer.parseInt( strT );
+		} catch ( final NumberFormatException e ) {
+			throw new IllegalArgumentException( String.format(
+					"ERROR\tFile list corrupt. Time could not be extracted for file %s.",
+					channelSourceFilenames.get( 0 ) ) );
+		}
+		
+		this.basisName = copy.basisName;
 	}
 
 	/**


### PR DESCRIPTION
Updates to make fluorescence datasets working.

Fluorescence datasets work with `-s 15` gauss blur. Should this be the default value for fluo mode?

Also, for one fluorescent dataset MoMA properties have to be changed (`SIGMA_GL_DETECTION_X = 25`) to avoid errors like this:
```
ERROR: Two maxima in a single pixel row found while looking for GL centerline 
```